### PR TITLE
Fix typo in spec Group.

### DIFF
--- a/package/yast2-alternatives.spec
+++ b/package/yast2-alternatives.spec
@@ -21,7 +21,7 @@ Release:        0
 License:        GPL-2.0
 Summary:        YaST2 - Manage Update-alternatives switching
 Url:            https://github.com/yast/yast-alternatives
-Group:          System/Yast
+Group:          System/YaST
 Source0:        %{name}-%{version}.tar.bz2
 BuildRequires:  yast2
 BuildRequires:  yast2-devtools


### PR DESCRIPTION
Incorrect case causes problems to translation tools and translators. See https://github.com/yast/yast-translations/pull/28#issuecomment-482556626