### PR TITLE
Added "BuildRequires: update-desktop-files"

### DIFF
--- a/package/yast2-alternatives.changes
+++ b/package/yast2-alternatives.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 19 09:09:41 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added "BuildRequires: update-desktop-files"
+- Related to the previous desktop file changes (fate#319035)
+- 4.2.1
+
+-------------------------------------------------------------------
 Fri May 31 12:24:51 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-alternatives.spec
+++ b/package/yast2-alternatives.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-alternatives
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 License:        GPL-2.0
 Summary:        YaST2 - Manage Update-alternatives switching
@@ -32,6 +32,7 @@ BuildRequires:  yast2-ruby-bindings
 BuildRequires:  rubygem(yast-rake)
 # For test
 BuildRequires:  rubygem(rspec)
+BuildRequires:  update-desktop-files
 
 %description
 A YaST2 module to manage update alternatives switching


### PR DESCRIPTION
- The recent fix in YaST RPM macros now updates the desktop files
- The `%suse_update_desktop_file` macro is defined in the `update-desktop-files` package
- Without it the macro is not expanded and the shell treats `%` as a job control character and fails with error `fg: no job control`