### PR TITLE
Fix help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage/
 doc/
 /.yardoc
 /*.pot
+/package/*.tar.bz2

--- a/package/yast2-alternatives.changes
+++ b/package/yast2-alternatives.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 18 22:10:43 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- Handle properly help command for alternatives client
+  (bsc#1172340)
+- 4.3.0
+
+-------------------------------------------------------------------
 Thu Jan 16 12:12:09 UTC 2020 - Dominique Leuenberger <dimstar@opensuse.org>
 
 - Clean spec file using spec-cleaner (main goal: use %license,

--- a/package/yast2-alternatives.spec
+++ b/package/yast2-alternatives.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-alternatives
-Version:        4.2.3
+Version:        4.3.0
 Release:        0
 Summary:        YaST2 - Manage Update-alternatives switching
 License:        GPL-2.0-only

--- a/src/lib/y2_alternatives/client/start_checking_permissions.rb
+++ b/src/lib/y2_alternatives/client/start_checking_permissions.rb
@@ -16,6 +16,7 @@
 #  To contact SUSE about this file by physical or electronic mail,
 #  you may find current contact information at www.suse.com
 
+require "yast"
 require "y2_alternatives/dialog/list_alternatives"
 
 Yast.import "Confirm"
@@ -24,8 +25,38 @@ module Y2Alternatives
   module Client
     # Checks if user is root and create a ListAlternatives dialog
     class StartCheckingPermissions
+      include Yast::I18n
+
       def main
+        textdomain "alternatives"
+
+        if Yast::WFM.Args.include?("help")
+          print_help
+          return true
+        elsif !Yast::WFM.Args.empty?
+          print_help
+          return false
+        end
+
         Dialog::ListAlternatives.run if Yast::Confirm.MustBeRoot
+      end
+
+    private
+
+      def print_help
+        # TRANSLATORS: %s stands for CLI program to use instead of yast module
+        msg = format(
+          _("This module does not support command line. Use '%s' instead."),
+          "update-alternatives"
+        )
+
+        cmdline_description = {
+          "id"   => "alternatives",
+          "help" => msg
+          }
+
+        Yast.import "CommandLine"
+        Yast::CommandLine.Run(cmdline_description)
       end
     end
   end

--- a/src/lib/y2_alternatives/client/start_checking_permissions.rb
+++ b/src/lib/y2_alternatives/client/start_checking_permissions.rb
@@ -53,7 +53,7 @@ module Y2Alternatives
         cmdline_description = {
           "id"   => "alternatives",
           "help" => msg
-          }
+        }
 
         Yast.import "CommandLine"
         Yast::CommandLine.Run(cmdline_description)


### PR DESCRIPTION
Adds basic CLI support saying that there is not CLI support. Otherwise bash completion will open module.

trello: https://trello.com/c/8G4FikEf/1988-ostumbleweed-p5-1172340-several-yast-modules-can-be-started-by-typing-yast2-module-tabtab

bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1172340